### PR TITLE
[py3k] removed relative imports

### DIFF
--- a/ipybell/__init__.py
+++ b/ipybell/__init__.py
@@ -1,3 +1,3 @@
-import bell
+from ipybell import bell
 def load_ipython_extension(ipython):
     ipython.register_magics(bell.BellMagic)

--- a/ipybell/bell.py
+++ b/ipybell/bell.py
@@ -3,7 +3,7 @@ __license__ = 'MIT'
 __version__ = '0.9'
 
 import ast
-import notifiers
+from ipybell import notifiers
 
 from IPython.core.error import UsageError
 from IPython.core.magic import magics_class, line_cell_magic


### PR DESCRIPTION
Removed relative imports.  This fixes ipython-bell to be compatible with Python 3.
